### PR TITLE
Removed authors to show kubecost logo and links in theme

### DIFF
--- a/_posts/2021-04-20-kubectl-cost-kubernetes-monitoring-cli.md
+++ b/_posts/2021-04-20-kubectl-cost-kubernetes-monitoring-cli.md
@@ -2,7 +2,6 @@
 title: "Hello kubectl cost: monitoring Kubernetes spend from the command line!"
 date: 2021-04-20T11:34:00-04:00
 canonical_url: "http://blog.kubecost.com/blog/kubectl-cost-kubernetes-monitoring-cli/"
-author: Michael Dresser
 classes: wide
 categories:
   - blog

--- a/_posts/2021-04-28-aks-cost.md
+++ b/_posts/2021-04-28-aks-cost.md
@@ -5,7 +5,6 @@ report on costs, calculate cluster efficiency and health, and alert on
 a budget excess."
 date: 2021-04-28T11:34:00-04:00
 canonical_url: "http://blog.kubecost.com/blog/aks-cost/"
-author: Ajay Tripathy
 classes: wide
 categories:
   - blog


### PR DESCRIPTION
The theme doesn't support showing Author information. Better not to have them.