### PR TITLE
Include HubSpot <script> block on all pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -87,6 +87,23 @@ footer:
       url: "https://github.com/"
 
 defaults:
+  # everything
+  - scope:
+      path: ""
+    values:
+      # This value gets embedded in the footer by _includes/footer/custom.html.
+      # The documentation for the custom footer in the Minimal Mistakes theme is
+      # here: https://mmistakes.github.io/minimal-mistakes/docs/layouts/#footer
+      #
+      # It would probably be better to use the after_footer_scripts in
+      # in _config.yaml, but the HubSpot documentation specifically requests
+      # the HTML below, including the "async defer" which cannot be specified
+      # with after_footer_scripts. Theme docs for after_footer_scripts:
+      # https://mmistakes.github.io/minimal-mistakes/docs/javascript/#customizing
+      hubspot_js: >-
+        <!-- Start of HubSpot Embed Code -->
+        <script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/8882461.js"></script>
+        <!-- End of HubSpot Embed Code -->
   # _posts
   - scope:
       path: ""

--- a/_includes/footer/custom.html
+++ b/_includes/footer/custom.html
@@ -1,0 +1,3 @@
+{% if page.hubspot_js %}
+    {{ page.hubspot_js }}
+{% endif %}


### PR DESCRIPTION
As noted in the comments, refer to the Minimal Mistakes theme's
documentation for custom footers and generic script values. I wish we
could specify "async defer" for after_footer_scripts, because this
change doesn't exactly match what HubSpot requests. I can either:
1. Include the <script> right before </body> without "async defer"
OR
2. Include the "async defer" but put the <script> in the footer div,
   which comes just before the \</body>

My suspicion is that "async defer" is more important for UX than
including at the end of the body, but I could be wrong.