### PR TITLE
Update fonts to match main website fonts

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,0 +1,5 @@
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter&family=Space+Mono&display=swap" rel="stylesheet">

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -14,7 +14,7 @@
 $sans-serif : "Inter", sans-serif;
 $monospace  : "Space Mono", monospace;
 
-$global-font-family : "Inter", $sans-serif;
+$global-font-family : $sans-serif;
 $header-font-family : "Space Grotesk", $sans-serif;
 
 @charset "utf-8";

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,0 +1,23 @@
+---
+# Only the main Sass file needs front matter (the dashes are enough)
+---
+
+// Reference for what's going on in this file:
+// https://mmistakes.github.io/minimal-mistakes/docs/stylesheets/#customizing
+// NB: "Before any @import lines"
+//
+// https://github.com/mmistakes/minimal-mistakes/discussions/1219#discussioncomment-172845
+// https://mmistakes.github.io/minimal-mistakes/docs/stylesheets/#font-stacks
+
+// Our custom font choices are imported in the <head> by using the built-in
+// custom head. See /_includes/head/custom.html
+$sans-serif : "Inter", sans-serif;
+$monospace  : "Space Mono", monospace;
+
+$global-font-family : "Inter", $sans-serif;
+$header-font-family : "Space Grotesk", $sans-serif;
+
+@charset "utf-8";
+
+@import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}"; // skin
+@import "minimal-mistakes"; // main partials


### PR DESCRIPTION
- Space Grotesk for headers
- Inter for regular text
- Space Mono for monospaced

 
Comments include details about Minimal Mistakes font config
and font importing.

I verified the correct fonts are getting passed in CSS with inspect element.

# Home page

## Before

<img width="679" alt="mainbefore" src="https://user-images.githubusercontent.com/17585786/153933463-1580183b-eec4-4442-afcb-25b0ebef7851.png">

## After

<img width="687" alt="mainafter" src="https://user-images.githubusercontent.com/17585786/153933465-aea228de-0cba-461d-8f3f-a3c8365f8039.png">

# Post header

## Before

<img width="696" alt="kopsbefore" src="https://user-images.githubusercontent.com/17585786/153933459-890c3f3e-25b7-4001-8cde-8ac58e605a43.png">

## After

<img width="708" alt="kopsafter" src="https://user-images.githubusercontent.com/17585786/153933462-727da92c-de37-4f78-984f-7f9ef24e9747.png">

# Code blocks

## Before

<img width="709" alt="codebefore" src="https://user-images.githubusercontent.com/17585786/153933454-eaeb2fc7-41d6-4870-8c6e-c35f46fb8460.png">

## After

<img width="703" alt="codeafter" src="https://user-images.githubusercontent.com/17585786/153933455-68ac63b4-e3d5-4f14-9c24-d1504f5a9a60.png">


